### PR TITLE
ci: add GitHub Actions workflow for lint, type-check & build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run linting
+        run: npm run lint
+
+      - name: Build application
+        run: npm run build
+        env:
+          NEXT_TELEMETRY_DISABLED: 1

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # moneyflow
 
+![CI](https://github.com/cseelus/moneyflow/actions/workflows/ci.yml/badge.svg)
+
 Track and visualize your monetary assets over time
 
 ## Setup


### PR DESCRIPTION
This PR implements the CI pipeline requested in issue #10.

## Changes Made

✅ **Created `.github/workflows/ci.yml`** that runs on `pull_request` and `push` to `main`
✅ **Uses Node.js 20** with npm cache via `actions/setup-node@v4`
✅ **Job steps implemented:**
   - Checkout the repository
   - Install dependencies with `npm ci`
   - Run `npm run lint` 
   - Run `npm run build` with `NEXT_TELEMETRY_DISABLED=1` to suppress telemetry
✅ **Added CI status badge** to the top of README.md

## Validation

- ✅ All steps pass locally
- ✅ Existing tests continue to pass (`npm run test:run`)
- ✅ Linting passes (`npm run lint`)
- ✅ Build succeeds (`npm run build`)
- ✅ Pre-commit hooks run successfully

## Acceptance Criteria Met

- ✅ Opening this PR will trigger the workflow
- ✅ Failing `npm run lint` locally will reproduce as a failed CI run
- ✅ README shows the CI badge once merged

Fixes #10

@cseelus can click here to [continue refining the PR](https://app.all-hands.dev/conversations/8765d7595d51467bb2efe12d5b2c4f11)